### PR TITLE
Feat: Resetting values in SettingsBase

### DIFF
--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -77,6 +77,16 @@ namespace OwlCore.Services
         }
 
         /// <summary>
+        /// Sets a settings value to its default.
+        /// </summary>
+        /// <param name="key">A unique identifier for this setting.</param>
+        /// <typeparam name="T">The type of the stored value.</typeparam>
+        protected void ResetSetting<T>([CallerMemberName] string key = "")
+        {
+            SetSetting<T>(default!, key);
+        }
+
+        /// <summary>
         /// Persists all settings from memory onto disk.
         /// </summary>
         /// <remarks>

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -87,6 +87,15 @@ namespace OwlCore.Services
         }
 
         /// <summary>
+        /// Sets all settings values to to their default.
+        /// </summary>
+        public void ResetAllSettings()
+        {
+            foreach (string key in _runtimeStorage.Keys)
+                ResetSetting(key);
+        }
+
+        /// <summary>
         /// Persists all settings from memory onto disk.
         /// </summary>
         /// <remarks>

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -87,7 +87,7 @@ namespace OwlCore.Services
         }
 
         /// <summary>
-        /// Sets all settings values to to their default.
+        /// Sets all settings values to their default.
         /// </summary>
         public void ResetAllSettings()
         {

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -80,10 +80,10 @@ namespace OwlCore.Services
         /// Sets a settings value to its default.
         /// </summary>
         /// <param name="key">A unique identifier for the setting.</param>
-        /// <typeparam name="T">The type of the stored value.</typeparam>
-        public void ResetSetting<T>(string key)
+        public void ResetSetting(string key)
         {
-            SetSetting<T>(default!, key);
+            _runtimeStorage.TryRemove(key, out _);
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(key));
         }
 
         /// <summary>

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -47,10 +47,11 @@ namespace OwlCore.Services
             if (value is null)
             {
                 _runtimeStorage.TryRemove(key, out _);
-                return;
             }
-
-            _runtimeStorage[key] = (typeof(T), value);
+            else
+            {
+                _runtimeStorage[key] = (typeof(T), value);
+            }
 
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(key));
         }

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -79,9 +79,9 @@ namespace OwlCore.Services
         /// <summary>
         /// Sets a settings value to its default.
         /// </summary>
-        /// <param name="key">A unique identifier for this setting.</param>
+        /// <param name="key">A unique identifier for the setting.</param>
         /// <typeparam name="T">The type of the stored value.</typeparam>
-        protected void ResetSetting<T>([CallerMemberName] string key = "")
+        public void ResetSetting<T>(string key)
         {
             SetSetting<T>(default!, key);
         }

--- a/tests/Services/SettingsBaseTests.cs
+++ b/tests/Services/SettingsBaseTests.cs
@@ -269,7 +269,7 @@ public class SettingsBaseTests
         settings.StringData = intermediateValue;
         Assert.AreEqual(intermediateValue, settings.StringData);
 
-        // Rest value
+        // Reset value
         settings.StringData = null!;
         Assert.AreEqual(TestSettings.StringData_DefaultValue, settings.StringData);
 

--- a/tests/Services/SettingsBaseTests.cs
+++ b/tests/Services/SettingsBaseTests.cs
@@ -304,8 +304,8 @@ public class SettingsBaseTests
         settings.StringData = intermediateValue;
         Assert.AreEqual(intermediateValue, settings.StringData);
 
-        // Rest value
-        settings.ResetStringData();
+        // Reset value
+        settings.ResetSetting<string>(nameof(settings.StringData));
         Assert.AreEqual(TestSettings.StringData_DefaultValue, settings.StringData);
 
         // Ensure only the assigned property changed.
@@ -446,8 +446,6 @@ public class SettingsBaseTests
             get => GetSetting(() => new CompositeTestSetting(Array.Empty<byte>(), string.Empty));
             set => SetSetting(value);
         }
-
-        public void ResetStringData() => ResetSetting<string>(nameof(StringData));
 
         public class CompositeTestSetting
         {

--- a/tests/Services/SettingsBaseTests.cs
+++ b/tests/Services/SettingsBaseTests.cs
@@ -305,7 +305,7 @@ public class SettingsBaseTests
         Assert.AreEqual(intermediateValue, settings.StringData);
 
         // Reset value
-        settings.ResetSetting<string>(nameof(settings.StringData));
+        settings.ResetSetting(nameof(settings.StringData));
         Assert.AreEqual(TestSettings.StringData_DefaultValue, settings.StringData);
 
         // Ensure only the assigned property changed.

--- a/tests/Services/SettingsBaseTests.cs
+++ b/tests/Services/SettingsBaseTests.cs
@@ -352,8 +352,8 @@ public class SettingsBaseTests
         Assert.AreEqual(TestSettings.StringData_DefaultValue, settings.StringData);
         Assert.AreEqual(TestSettings.State_DefaultValue, settings.State);
 
-        // Ensure all properties changed.
-        Assert.AreEqual(2 * 2 + 1, changedProperties.Count);
+        // Ensure properties changed a second time due to reset.
+        Assert.AreEqual(2 + 2 + 1, changedProperties.Count);
         Assert.AreEqual(2, changedProperties.Count(p => p == nameof(settings.StringData)));
         Assert.AreEqual(2, changedProperties.Count(p => p == nameof(settings.CompositeData)));
         Assert.AreEqual(1, changedProperties.Count(p => p == nameof(settings.State)));


### PR DESCRIPTION
# Background
This PR introduces two options for resetting a setting to its default value.
Closes #3

# Motivation
Resetting could previously be achieved by setting the property to `null`, but this did not fire `PropertyChanged` and could be unintuitive for consumers.

# Proposal
- Fix #3 by making `SetSetting<T>(T value, string key)` always invoke the `PropertyChanged` event
- Add `ResetSetting<T>(string key)` to allow explicit resetting of properties