### PR TITLE
Made some improvements to SettingsBase

### DIFF
--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -44,9 +44,9 @@ namespace OwlCore.Services
         protected bool FlushDefaultValues { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the property that determines whether to only persist settings when they are changed through <see cref="SetSetting{T}"/>.
+        /// Gets or sets a value that determines whether or not to flush settings that are unchanged in memory.
         /// </summary>
-        protected bool PersistIfChanged { get; set; }
+        protected bool FlushOnlyChangedValues { get; set; }
 
         /// <summary>
         /// A folder abstraction where the settings can be stored and persisted.

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -40,7 +40,7 @@ namespace OwlCore.Services
         /// <summary>
         /// Gets or sets the property that determines whether to flush default values to disk.
         /// </summary>
-        protected bool FlushDefaultValues { get; set; }
+        protected bool FlushDefaultValues { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the property that determines whether to only persist settings when they are changed through <see cref="SetSetting{T}"/>.

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -44,7 +44,8 @@ namespace OwlCore.Services
         protected bool FlushDefaultValues { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value that determines whether or not to flush settings that are unchanged in memory. Setting to true is recommended if you don't expect others to modify the settings files.
+        /// Gets or sets a value that determines whether or not to flush settings that are unchanged in memory.
+        /// Setting to true is recommended if you don't expect others to modify the settings files.
         /// </summary>
         protected bool FlushOnlyChangedValues { get; set; }
 

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -37,6 +37,11 @@ namespace OwlCore.Services
         }
 
         /// <summary>
+        /// Gets or sets the property that determines whether to flush default values to disk.
+        /// </summary>
+        protected bool FlushDefaultValues { get; set; }
+
+        /// <summary>
         /// A folder abstraction where the settings can be stored and persisted.
         /// </summary>
         public IFolderData Folder { get; }
@@ -84,7 +89,7 @@ namespace OwlCore.Services
 
             // Null values are never stored in runtime or persistent storage.
             if (fallbackValue is not null)
-                _runtimeStorage[key] = new(typeof(T), fallbackValue, false);
+                _runtimeStorage[key] = new(typeof(T), fallbackValue, FlushDefaultValues);
 
             return fallbackValue;
         }

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -39,6 +39,7 @@ namespace OwlCore.Services
 
         /// <summary>
         /// Gets or sets the property that determines whether to flush default values to disk.
+        /// Setting to false is recommended if your default values never change.
         /// </summary>
         protected bool FlushDefaultValues { get; set; }
 

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -43,6 +43,11 @@ namespace OwlCore.Services
         protected bool FlushDefaultValues { get; set; }
 
         /// <summary>
+        /// Gets or sets the property that determines whether to only persist settings when they are changed through <see cref="SetSetting{T}"/>.
+        /// </summary>
+        protected bool PersistIfChanged { get; set; }
+
+        /// <summary>
         /// A folder abstraction where the settings can be stored and persisted.
         /// </summary>
         public IFolderData Folder { get; }
@@ -135,7 +140,7 @@ namespace OwlCore.Services
                 try
                 {
                     // Don't save settings whose value didn't change
-                    if (!kvp.Value.IsDirty)
+                    if (PersistIfChanged && !kvp.Value.IsDirty)
                         continue;
 
                     var dataFile = await Folder.CreateFileAsync(kvp.Key, CreationCollisionOption.OpenIfExists);

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -141,7 +141,7 @@ namespace OwlCore.Services
                 try
                 {
                     // Don't save settings whose value didn't change
-                    if (PersistIfChanged && !kvp.Value.IsDirty)
+                    if (FlushOnlyChangedValues && !kvp.Value.IsDirty)
                         continue;
 
                     var dataFile = await Folder.CreateFileAsync(kvp.Key, CreationCollisionOption.OpenIfExists);

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -84,7 +84,7 @@ namespace OwlCore.Services
 
             // Null values are never stored in runtime or persistent storage.
             if (fallbackValue is not null)
-                _runtimeStorage[key] = new(typeof(T), fallbackValue);
+                _runtimeStorage[key] = new(typeof(T), fallbackValue, false);
 
             return fallbackValue;
         }

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Diagnostics;
 using OwlCore.AbstractStorage;
 
 namespace OwlCore.Services
@@ -256,8 +257,11 @@ namespace OwlCore.Services
             var typeFileBytes = new byte[typeFileStream.Length];
             var read = await typeFileStream.ReadAsync(typeFileBytes, 0, typeFileBytes.Length, token);
 
+            // Check amount read
+            Guard.HasSizeEqualTo(typeFileBytes, read);
+
             // Read bytes as string
-            return Encoding.UTF8.GetString(typeFileBytes.Take(read).ToArray());
+            return Encoding.UTF8.GetString(typeFileBytes);
         }
 
         /// <inheritdoc />

--- a/src/Services/SettingsBase.cs
+++ b/src/Services/SettingsBase.cs
@@ -44,7 +44,7 @@ namespace OwlCore.Services
         protected bool FlushDefaultValues { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value that determines whether or not to flush settings that are unchanged in memory.
+        /// Gets or sets a value that determines whether or not to flush settings that are unchanged in memory. Setting to true is recommended if you don't expect others to modify the settings files.
         /// </summary>
         protected bool FlushOnlyChangedValues { get; set; }
 


### PR DESCRIPTION
This PR adds some improvements and silent fixes to `SettingsBase` class:
- The wrapper for setting values has been separated into a `record class` with additional `IsDirty` property that determines whether to write the setting value or not.
- Internal `ReadFileAsStringAsync()` now decodes strings taking `bytesRead` into consideration.
- Always check for ".Type" string in `LoadAsync()` (previously only checked for "Type").